### PR TITLE
Removing ticket section

### DIFF
--- a/src/pages/home-page.html
+++ b/src/pages/home-page.html
@@ -5,7 +5,6 @@
 <link rel="import" href="../elements/about-block.html">
 <link rel="import" href="../elements/speakers-block.html">
 <link rel="import" href="../elements/latest-posts-block.html">
-<link rel="import" href="../elements/tickets-block.html">
 <link rel="import" href="../elements/partners-block.html">
 <link rel="import" href="../elements/featured-videos.html">
 <link rel="import" href="../elements/subscribe-block.html">


### PR DESCRIPTION
@matthiasa4 

I think it is best to just link the first Button in Hero block to Eventbrite page, because:
1. Fewer links for users to go through
2. The tickets block have Buy Tickets and Free at the same place. Also it is not that pretty and doesn't add functionality :) 